### PR TITLE
Quick fix

### DIFF
--- a/src/adaptors/GearsSQLiteAdaptor.js
+++ b/src/adaptors/GearsSQLiteAdaptor.js
@@ -165,11 +165,12 @@ GearsSQLiteAdaptor.prototype = {
 			// FIXME need to test null return / empty recordset
 			var o = this.deserialize(rs.field(1));
 			o.key = key;
+			rs.close();
 			callback(o);
 		} else {
+			rs.close();
 			callback(null);
 		}
-		rs.close();
 	},
 	all:function(callback) {
 		var cb	= this.terseToVerboseCallback(callback);


### PR DESCRIPTION
Hello,

I am using Lawnchair in the browser on Android 1.6 using the gears adaptor, and as I started to make more use of callbacks my phone started moaning about database locks. I had a poke around in the adaptor and saw that the callback (in which I was often doing other database stuff) was getting called before the result was closed. Closing it first fixed my code.

Jos
