### PR TITLE
Addition to 'revive' ISO-encoded dates that have been stringified

### DIFF
--- a/src/adaptors/LawnchairAdaptorHelpers.js
+++ b/src/adaptors/LawnchairAdaptorHelpers.js
@@ -51,7 +51,19 @@ var LawnchairAdaptorHelpers = {
 		}
 		return uuid.join('');
 	},
-
+  
+  // parse a json serialized date from douglas crockford's json2.js
+  parseISODate: function (key, value) {
+    var a;
+    if (typeof value === 'string') {
+      a = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2}(?:\.\d*)?)Z$/.exec(value);
+      if (a) {
+        return new Date(Date.UTC(+a[1], +a[2] - 1, +a[3], +a[4], +a[5], +a[6]));
+      }
+    }
+    return value;
+  },
+  
 	// Serialize a JSON object as a string.
 	serialize: function(obj) {
 		var r = '';
@@ -61,6 +73,8 @@ var LawnchairAdaptorHelpers = {
 
 	// Deserialize JSON.
 	deserialize: function(json) {
-		return eval('(' + json + ')');
+	  return JSON.parse(json);
+	  // uncomment to parse Date strings
+	  // return JSON.parse(json, this.parseISODate);
 	}
 };


### PR DESCRIPTION
I'd been using dates recently for a project and noticed that lawnchair was correctly stringifying Date() instances, but it wasn't deserializing them correctly.

This basically adds a parseISODate function to the lawnchair adapter helpers and then has a commented version of deserialize that uses `JSON.parse(json,this.parseISODate)` to 'revive' the iso-encoded date. (this also assumes that it's ok to use JSON.parse rather than eval-ing the json, but json2 seems to be an implicit dependency, so it seems like a good idea to use it)

I'm assuming there's a reason that this isn't baked in by default, but the option to enable it is pretty handy, so i'm throwing in a pull request.

best,  
--marcos
