### PR TITLE
Resolves issue where values with integer keys can't be removed

### DIFF
--- a/src/adapters/dom.js
+++ b/src/adapters/dom.js
@@ -135,7 +135,7 @@ Lawnchair.adapter('dom', (function() {
         },
         
         remove: function (keyOrObj, callback) {
-            var key = this.name + '.' + (typeof keyOrObj === 'string' ? keyOrObj : keyOrObj.key)
+            var key = this.name + '.' + ((keyOrObj.key) ? keyOrObj.key : keyOrObj)
             this.indexer.del(key)
             storage.removeItem(key)
             if (callback) this.lambda(callback).call(this)


### PR DESCRIPTION
Hi guys,

I'm not sure what testing you guys are looking for here.

This LoC fixes an issue where values with integer keys can't be deleted, as previously if the key wasn't a string it was assumed to be an object. There is similar code in the blackberry file but I'm not sure if that is required to be a string. All I know is this change works for me, locally.
