### PR TITLE
Prevent that the window.name adapter looses history everytime the adapter

### DIFF
--- a/src/adapters/window-name.js
+++ b/src/adapters/window-name.js
@@ -10,7 +10,7 @@ Lawnchair.adapter('window-name', (function(index, store) {
         },
 
         init: function (options, callback) {
-            data[this.name] = {index:[],store:{}}
+            data[this.name] = data[this.name] || {index:[],store:{}}
             index = data[this.name].index
             store = data[this.name].store
             this.fn(this.name, callback).call(this, this)


### PR DESCRIPTION
Prevent that the window.name adapter looses history everytime the adapter is inited

Currently everytime you refresh the page and the init method is envoked the data entry is emptied
