### PR TITLE
No adapter selected when options.adapter has a value

### DIFF
--- a/src/Lawnchair.js
+++ b/src/Lawnchair.js
@@ -28,7 +28,12 @@ var Lawnchair = function (options, callback) {
     var adapter
     // if the adapter is passed in we try to load that only
     if (options.adapter) {
-        adapter = Lawnchair.adapters[this.indexOf(Lawnchair.adapters, options.adapter)]
+        for (var i = 0; i < Lawnchair.adapters.length; i++) {
+            if (Lawnchair.adapters[i].adapter === options.adapter) {
+              adapter = Lawnchair.adapters[i];
+              break;
+            }
+        }
         adapter = adapter.valid() ? adapter : undefined
     // otherwise find the first valid adapter for this env
     } 


### PR DESCRIPTION
When options.adapter has a value (like webkit-sqlite) your version attempts to select the item from Lawnchair.adapters where the key equals options.adapter. Lawnchair.adapters has numeric keys, so an adapter is never selected. I fixed this by looping through Lawnchair.adapters and checking to see which adapter's adapter member is equal to options.adapter.
