### PR TITLE
Adding `exists` method for dom adaptater

### DIFF
--- a/src/adapters/dom.js
+++ b/src/adapters/dom.js
@@ -117,6 +117,12 @@ Lawnchair.adapter('dom', (function() {
             }
             return this
         },
+
+        exists: function (key, cb) {
+            var exists = this.indexer.find(this.name+'.'+key) === false ? false : true ;
+            this.lambda(cb).call(this, exists);
+            return this;
+        },
         // NOTE adapters cannot set this.__results but plugins do
         // this probably should be reviewed
         all: function (callback) {


### PR DESCRIPTION
The issue #49 deplored the absence of the `exists` method for the _dom_ adaptater whereas the method is present in the API description. 

Here is a basic but working implementation of this method.

Please merge it if you are interested.
