### PR TITLE
where variable (vs. record.variable) is expected to work (docs do not reflect real world functionality)

### DIFF
--- a/test/plugin/query.html
+++ b/test/plugin/query.html
@@ -55,8 +55,11 @@
                     this.where('record.a === 1', function(a) {
                         ok(a, 'can query on a property') 
                     }) 
+                    this.where('a === ?', 1, function(a){
+                        equals(records[2], 'can interpolate query with variable ("a === ?")')
+                    })
                     this.where('record.a === ?', 1, function(a){
-                        ok(a, 'can interpolate query with variable')
+                        equals(records[2], 'can interpolate query with variable ("record.a === ?")')
                     })
                     this.where('record.a === ? && record != ?', 1, undefined, function(a){
                         ok(a, 'can interpolate query with many  variables')


### PR DESCRIPTION
as per http://westcoastlogic.com/lawnchair/plugins/ where("varName = 'value'") should work in addition to where("record.varName = 'value'"). Added qunit tests to reflect this.

These tests currently fail however unfortunately thats as far as I go, I'm not sure where to actually fix this.
