### PR TITLE
fixed private browsing mode in mobile safari

### DIFF
--- a/src/adapters/dom.js
+++ b/src/adapters/dom.js
@@ -56,7 +56,19 @@ Lawnchair.adapter('dom', (function() {
     
         // ensure we are in an env with localStorage 
         valid: function () {
-            return !!storage 
+            return !!storage && function() {
+              // in mobile safari if safe browsing is enabled, window.storage
+              // is defined but setItem calls throw exceptions.
+              var success = true
+              var value = Math.random()
+              try {
+                storage.setItem(value, value)
+              } catch (e) {
+                success = false
+              }
+              storage.removeItem(value)
+              return success
+            }()
         },
 
         init: function (options, callback) {


### PR DESCRIPTION
If mobile safari is in private browsing mode window.localStorage is defined but calling setItem() throws an exception. This commit checks for this in the dom adapter's valid() function.
