### PR TITLE
JS error in domadapter.keys method in IE versions below 9 

### DIFF
--- a/src/adapters/dom.js
+++ b/src/adapters/dom.js
@@ -104,9 +104,18 @@ Lawnchair.adapter('dom', (function() {
        
         // accepts [options], callback
         keys: function(callback) {
-            if (callback) { 
+            if (callback) {
                 var name = this.name
-                ,   keys = this.indexer.all().map(function(r){ return r.replace(name + '.', '') })
+                var indices = this.indexer.all();
+                var keys = [];
+                //Checking for the support of map.
+                if(Array.prototype.map) {
+                    keys = indices.map(function(r){ return r.replace(name + '.', '') })
+                } else {
+                    for (var key in indices) {
+                        keys.push(key.replace(name + '.', ''));
+                    }
+                }
                 this.fn('keys', callback).call(this, keys)
             }
             return this // TODO options for limit/offset, return promise


### PR DESCRIPTION
Array map method is supported only from IE 9 and hence in versions lesser than that usage of map method is throwing a javascript error. In this case in domadapter.keys method. Fixed it by checking for the support of the method and creating the keys array manually if map method is not supported.
