### PR TITLE
Make init callback optional

### DIFF
--- a/src/Lawnchair.js
+++ b/src/Lawnchair.js
@@ -11,14 +11,12 @@ var Lawnchair = function (options, callback) {
     // lawnchair requires json 
     if (!JSON) throw 'JSON unavailable! Include http://www.json.org/json2.js to fix.'
     // options are optional; callback is not
-    if (arguments.length <= 2 && arguments.length > 0) {
+    if (arguments.length <= 2) {
         callback = (typeof arguments[0] === 'function') ? arguments[0] : arguments[1];
-        options  = (typeof arguments[0] === 'function') ? {} : arguments[0];
+        options  = (typeof arguments[0] === 'function') ? {} : arguments[0] || {};
     } else {
         throw 'Incorrect # of ctor args!'
     }
-    // TODO perhaps allow for pub/sub instead?
-    if (typeof callback !== 'function') throw 'No callback was provided';
     
     // default configuration 
     this.record = options.record || 'record'  // default for records

--- a/test/lawnchair-spec.js
+++ b/test/lawnchair-spec.js
@@ -6,29 +6,38 @@ module('Lawnchair construction/destruction', {
     }
 });
 
-test('ctor requires callbacks in each form', function() {
+test('ctor only calls callback if passed one', function() {
     QUnit.stop();
-    QUnit.expect(6);
+    QUnit.expect(9);
 
-    // raise exception if no ctor callback is supplied
     try {
-        var lc2 = new Lawnchair();    
+        var lc2 = new Lawnchair();
+        ok(true, 'no exception raised if no callback supplied to init');
     } catch(e) {
-        ok(true, 'exception raised if no callback supplied to init');
+        ok(false, 'exception raised if no callback supplied to init');
     }
     try {
         var lc3 = new Lawnchair({}, {});
+        ok(false, 'no exception raised if second argument passed but not a callback');
     } catch(e) {
-        ok(true, 'exception raised if no callback supplied to init, but two args are present');
+        ok(true, 'exception raised if second argument passed but not a callback');
     }
     try {
         var lc3 = new Lawnchair({});
+        ok(true, 'no exception raised if no callback supplied to init, but one arg is present');
     } catch(e) {
-        ok(true, 'exception raised if no callback supplied to init, but one arg is present');
+        ok(false, 'exception raised if no callback supplied to init, but one arg is present');
     }
 
     var lc = new Lawnchair({name:store.name}, function(ref) {
         ok(true, 'should call passed in callback when using obj+function ctor form')
+        equals(this, ref, "lawnchair callback scoped to lawnchair instance")
+        equals(ref, this, "lawnchair passes self into callback too")
+        QUnit.start()
+    });
+
+    var lc = new Lawnchair(function(ref) {
+        ok(true, 'should call passed in callback when using function ctor form')
         equals(this, ref, "lawnchair callback scoped to lawnchair instance")
         equals(ref, this, "lawnchair passes self into callback too")
         QUnit.start()


### PR DESCRIPTION
Hey Brian,

As we discussed during JSConf.eu, I think callbacks should actually be optional, especially when dealing with storage adapters we know are synchronous (e.g. localStorage). I see a lot of people just passing $.noop or Prototype.emptyFunction or function(){} as final arg, just because they have to.

So here's my pull request, with relevant passing tests :-)

Cheers!
