### PR TITLE
Made webkit-sqlite adapter database size configurable

### DIFF
--- a/src/adapters/webkit-sqlite.js
+++ b/src/adapters/webkit-sqlite.js
@@ -29,7 +29,7 @@ Lawnchair.adapter('webkit-sqlite', (function () {
             ,   create = "CREATE TABLE IF NOT EXISTS " + this.record + " (id NVARCHAR(32) UNIQUE PRIMARY KEY, value TEXT, timestamp REAL)"
             ,   win    = function(){ return cb.call(that, that); }
             // open a connection and create the db if it doesn't exist 
-            this.db = openDatabase(this.name, '1.0.0', this.name, 65536)
+            this.db = openDatabase(this.name, '1.0.0', this.name, options.maxSize || 65536)
             this.db.transaction(function (t) { 
                 t.executeSql(create, [], win, fail) 
             })


### PR DESCRIPTION
Max size of database was configured to 65536 bytes which is too little for many cases. Now max size is configurable.
