### PR TITLE
Adding support for Bower package manager

### DIFF
--- a/component.json
+++ b/component.json
@@ -1,0 +1,8 @@
+{
+  "name": "lawnchair",
+  "version": "0.6.3",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/brianleroux/lawnchair.git"
+  }
+}


### PR DESCRIPTION
Bower is as the creators ( Twitter ) say :
THE BROWSER PACKAGE MANAGER
html, css, and javascript
http://twitter.github.com/bower/

Under "Authoring packages" you can see that you only need to add this component.json file and once is pushed to the git repository run this command:

bower register skeleton https://github.com/dhgamache/Skeleton.git

This will allow anyone on bower to do a "bower search skeleton" and find this package, and install it with a "bower install skeleton".

In the meanwhile i'm installing from the url in github.
