### PR TITLE
Cyclic references while saving break dom-adapter, and other adapters do not return.

### DIFF
--- a/src/adapters/dom.js
+++ b/src/adapters/dom.js
@@ -78,11 +78,11 @@ Lawnchair.adapter('dom', (function() {
         
         save: function (obj, callback) {
             var key = obj.key ? this.name + '.' + obj.key : this.name + '.' + this.uuid()
-            // if the key is not in the index push it on
-            if (this.indexer.find(key) === false) this.indexer.add(key)
             // now we kil the key and use it in the store colleciton    
             delete obj.key;
             storage.setItem(key, JSON.stringify(obj))
+            // if the key is not in the index push it on
+            if (this.indexer.find(key) === false) this.indexer.add(key)
             obj.key = key.slice(this.name.length + 1)
             if (callback) {
                 this.lambda(callback).call(this, obj)

--- a/src/adapters/window-name.js
+++ b/src/adapters/window-name.js
@@ -42,7 +42,18 @@ Lawnchair.adapter('window-name', (function() {
                     this.index.push(key)
                 }
                 this.store[key] = obj
-                window.top.name = JSON.stringify(data) // TODO wow, this is the only diff from the memory adapter
+
+                try {
+                    window.top.name = JSON.stringify(data) // TODO wow, this is the only diff from the memory adapter
+                } catch(e) {
+                    // restore index/store to previous value before JSON exception
+                    if (!exists) {
+                        this.index.pop();
+                        delete this.store[key];
+                    }
+                    throw e;
+                }
+
                 if (cb) {
                     obj.key = key
                     this.lambda(cb).call(this, obj)


### PR DESCRIPTION
Prevent '_index_' getting saved from dom adapter without matching object. Prevents total breakage.
 Prevent non-return of save method from webkit-sqlite adapter.
 Prevent inconsistent state in window-name adapter after save.
