### PR TITLE
Use 'id' as key

### DIFF
--- a/src/adapters/dom.js
+++ b/src/adapters/dom.js
@@ -77,9 +77,10 @@ Lawnchair.adapter('dom', (function() {
         },
         
         save: function (obj, callback) {
-            var key = obj.key ? this.name + '.' + obj.key : this.name + '.' + this.uuid()
-            // now we kil the key and use it in the store colleciton    
-            delete obj.key;
+            var key_name = obj.id || obj.key;
+            var key = key_name ? this.name + '.' + key_name : this.name + '.' + this.uuid()
+            // now we kil the key and use it in the store colleciton
+            if(obj.key) delete obj.key;
             storage.setItem(key, JSON.stringify(obj))
             // if the key is not in the index push it on
             if (this.indexer.find(key) === false) this.indexer.add(key)

--- a/src/adapters/indexed-db.js
+++ b/src/adapters/indexed-db.js
@@ -147,8 +147,9 @@ Lawnchair.adapter('indexed-db', (function(){
 
          var trans = this.db.transaction(STORE_NAME, READ_WRITE);
          var store = trans.objectStore(STORE_NAME);
-         if (obj.key) {
-             request = store.put(obj, obj.key);
+         var key = obj.id || obj.key;
+         if (key) {
+             request = store.put(obj, key);
          } else if (this.useAutoIncrement) {
              request = store.put(obj); // use autoIncrementing key.
          } else {

--- a/src/adapters/memory.js
+++ b/src/adapters/memory.js
@@ -19,8 +19,8 @@ Lawnchair.adapter('memory', (function(){
         },
 
         save: function(obj, cb) {
-            var key = obj.key || this.uuid()
-            
+            var key = obj.id || obj.key || this.uuid()
+
             this.exists(key, function(exists) {
                 if (!exists) {
                     if (obj.key) delete obj.key

--- a/src/adapters/webkit-sqlite.js
+++ b/src/adapters/webkit-sqlite.js
@@ -59,14 +59,15 @@ Lawnchair.adapter('webkit-sqlite', (function () {
         // you think thats air you're breathing now?
         save: function (obj, callback, error) {
             var that = this
-            ,   id   = obj.key || that.uuid()
+            ,   key  = obj.id || obj.key
+            ,   id   = key || that.uuid()
             ,   ins  = "INSERT INTO " + this.record + " (value, timestamp, id) VALUES (?,?,?)"
             ,   up   = "UPDATE " + this.record + " SET value=?, timestamp=? WHERE id=?"
             ,   win  = function () { if (callback) { obj.key = id; that.lambda(callback).call(that, obj) }}
             ,   val  = [now(), id]
             ,   error= error || function() {}
-            // existential 
-            that.exists(obj.key, function(exists) {
+            // existential
+            that.exists(id, function(exists) {
                 // transactions are like condoms
                 that.db.transaction(function(t) {
                     try {

--- a/test/lawnchair-spec.js
+++ b/test/lawnchair-spec.js
@@ -281,6 +281,38 @@ test( 'save without callback', function() {
 
 });
 
+test( 'save prefers id as key field', function() {
+
+    QUnit.stop();
+    QUnit.expect(1);
+
+    me['id'] = '2';  // Setting the id fields
+    me['key'] = "two";
+
+    store.save(me, function(obj) {
+        this.get('2', function(o) {
+            equals(o.name, me.name, "saving uses id as key");
+            QUnit.start();
+        });
+    });
+});
+
+test( 'save falls back on key as key field', function() {
+
+    QUnit.stop();
+    QUnit.expect(1);
+
+    me['key'] = "two";  // Setting the id fields
+
+    store.save(me, function(obj) {
+        this.get("two", function(o) {
+            equals(o.name, me.name, "saving falls back on key as key");
+            QUnit.start();
+        });
+    });
+});
+
+
 module('batch()', {
     setup:function() {
         QUnit.stop();


### PR DESCRIPTION
Adding the ability to use 'id' as the record key instead of manually specifying 'key' before save()'ing.

The rationale is that if I'm receiving data from the backend server, it's more likely that the primary key is named 'id' than it is named 'key', so this patch handles that.

I've only patched the adapters for memory, dom, webkit-sql and indexeddb though.

Tests included
