### PR TITLE
Fix query interpolation

### DIFF
--- a/src/plugins/query.js
+++ b/src/plugins/query.js
@@ -47,7 +47,7 @@ Lawnchair.plugin((function(){
             // overwrite working results
             this.__results = r
             // callback / chain
-            if (args.length === 1) this.fn(this.name, last).call(this, this.__results)   
+            if (args.length) this.fn(this.name, last).call(this, this.__results)
             return this 
         },  
 


### PR DESCRIPTION
Thinking that interpolation might be more neatly done via str.replace() instead of string splitting along '?' characters. This patch allows for multiple interpolations as well, eg.

```
this.where("user.name === ? || user.age > ?", "john", 3, function(data) { 
    /* do stuff */ 
})
```

This patch also ensures that the callback is called at the end of the query
