### PR TITLE
Support for Blob object. BlobBuilder legacy support in an if block.

### DIFF
--- a/src/adapters/html5-filesystem.js
+++ b/src/adapters/html5-filesystem.js
@@ -4,6 +4,13 @@ Lawnchair.adapter('html5-filesystem', (function(global){
     var TEMPORARY = global.TEMPORARY || StorageInfo.TEMPORARY;
     var PERSISTENT = global.PERSISTENT || StorageInfo.PERSISTENT;
     var BlobBuilder = global.BlobBuilder || global.WebKitBlobBuilder;
+    // BlobBuilder is depricated, use Blob
+    if(BlobBuilder){
+        throw('this browser has not depricated BlobBuilder. you probably want to update.');
+    }else{
+        console.log('this modern browser has depricated BlobBuilder, use Blob instead')
+        // see: https://developer.mozilla.org/en-US/docs/DOM/Blob#Blob_constructor_example_usage
+    }
     var requestFileSystem = global.requestFileSystem || global.webkitRequestFileSystem || global.moz_requestFileSystem;
     var FileError = global.FileError;
 
@@ -98,10 +105,15 @@ Lawnchair.adapter('html5-filesystem', (function(global){
                         writer.onwriteend = function() {
                             if ( callback ) me.lambda( callback ).call( me, obj );
                         };
-
-                        var builder = new BlobBuilder();
-                        builder.append( JSON.stringify( obj ) );
-                        writer.write( builder.getBlob( 'application/json' ) );
+                        // Old, depricated
+                        if(BlobBuilder){
+                            var builder = new BlobBuilder();
+                            builder.append( JSON.stringify( obj ) );
+                            writer.write( builder.getBlob( 'application/json' ) );
+                        }else{
+                        // new, kinky
+                            writer.write( new Blob([JSON.stringify(obj)] , {'type': 'application/json'}) );
+                        }
                     }, error );
                 }, error );
             });


### PR DESCRIPTION
I followed the MDN example for changing BlobBuilder code to Blob, since webkit depricated BlobBuilder. Consequently, the html5-filesystem adapter broke in recent versions of Chrome.

The old code lives in an if block to support older browsers.

https://developer.mozilla.org/en-US/docs/DOM/Blob#Blob_constructor_example_usage

resolves issue: 

https://github.com/brianleroux/lawnchair/issues/147
