### PR TITLE
Moved code inside callback and the predicate call.

### DIFF
--- a/src/plugins/query.js
+++ b/src/plugins/query.js
@@ -38,13 +38,13 @@ Lawnchair.plugin((function(){
             // TODO should we allow for chained where() to filter __results? (I'm thinking no b/c creates funny behvaiors w/ callbacks)
             this.all(function(all){
                 for (var i = 0, l = all.length; i < l; i++) {
-                    if (is(all[i])) r.push(all[i])
+                    if (is.call(all[i])) r.push(all[i])
                 }
+                // overwrite working results
+                this.__results = r
+                // callback / chain
+                if (args.length === 1) this.fn(this.name, last).call(this, this.__results)   
             })
-            // overwrite working results
-            this.__results = r
-            // callback / chain
-            if (args.length === 1) this.fn(this.name, last).call(this, this.__results)   
             return this 
         },  
 


### PR DESCRIPTION
The assignment of results was not inside the callback.  The 'is' predicate function was being passed the 'record' name every time so it didn't have good access to the actual record being inspected; it's now passed as 'this'.
