### PR TITLE
Add missing semicolons that break JS concatenation

### DIFF
--- a/src/adapters/memory.js
+++ b/src/adapters/memory.js
@@ -102,4 +102,4 @@ Lawnchair.adapter('memory', (function(){
         }
     }
 /////
-})())
+})());

--- a/src/adapters/touchdb-couchdb.js
+++ b/src/adapters/touchdb-couchdb.js
@@ -248,4 +248,4 @@ Lawnchair.adapter('touchdb-couchdb', (function(){
         }
     }
 /////
-})())
+})());

--- a/src/adapters/webkit-sqlite.js
+++ b/src/adapters/webkit-sqlite.js
@@ -184,4 +184,4 @@ Lawnchair.adapter('webkit-sqlite', (function () {
 			return this
 		}
 //////
-}})())
+}})());

--- a/src/adapters/window-name.js
+++ b/src/adapters/window-name.js
@@ -127,4 +127,4 @@ Lawnchair.adapter('window-name', (function() {
         }
     }
 /////
-})())
+})());


### PR DESCRIPTION
Without this, JS concatenation can fail under some circumstances.
