### PR TITLE
Update exception to non deprecated

### DIFF
--- a/src/adapters/indexed-db.js
+++ b/src/adapters/indexed-db.js
@@ -29,7 +29,7 @@ Lawnchair.adapter('indexed-db', (function(){
   var getIDBDatabaseException = function() {
       return window.IDBDatabaseException || window.webkitIDBDatabaseException ||
           window.mozIDBDatabaseException || window.oIDBDatabaseException ||
-          window.msIDBDatabaseException;
+          window.msIDBDatabaseException || window.DOMException;
   };
   var useAutoIncrement = function() {
       // using preliminary mozilla implementation which doesn't support


### PR DESCRIPTION
IDBDatabaseException (or mozIDBDatabaseException) seems to be obsolete according to this https://developer.mozilla.org/en-US/docs/Web/API/IDBDatabaseException and should be replaced by DomException.
