### PR TITLE
Fixed a couple of issues in query plugin.

### DIFF
--- a/src/plugins/query.js
+++ b/src/plugins/query.js
@@ -7,9 +7,8 @@ Lawnchair.plugin((function(){
     var interpolate = function(template, args) {
         var parts = template.split('?').filter(function(i) { return i != ''})
         ,   query = ''
-
         for (var i = 0, l = parts.length; i < l; i++) {
-            query += parts[i] + args[i]    
+            query += parts[i] + (args[i] ? args[i] : '');
         }
         return query
     }
@@ -43,7 +42,9 @@ Lawnchair.plugin((function(){
                 // overwrite working results
                 this.__results = r
                 // callback / chain
-                if (args.length === 1) this.fn(this.name, last).call(this, this.__results)   
+                if (typeof(last) === 'function')  {
+                    this.fn(this.name, last).call(this, this.__results)
+                }
             })
             return this 
         },  


### PR DESCRIPTION
Two issues found while implementing a site using this plugin:
1. interpolate was crashing on the last part[i] iteration because parts array is often one element larger than args array.

Fixed by adding graceful handling for undefined args[i].
1. In my tests, args.length was never equal to 1, so the callback function was never being called. This was trying test that the last argument was a callback, but wasn't working.

Fixed by changing the test to look at the last arg and check directly that it is a function. The callback is now called as expected.

These fixes allowed me to write queries like this:

```
db.where('this.rec.address1.match(/?/i) || this.rec.address2.match(/?/i)',searchFor,searchFor,function(recs) {
    $.each(recs, function(i,rec) {
        console.log(rec);
    });
});
```

Previously the query plug-in only worked if the query string ended with a ? placeholder.
