### PR TITLE
update to new version number and renamed component.json (deprecated) to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "lawnchair",
   "repo": "brianleroux/lawnchair",
   "description": "A lightweight, adaptive, simple and elegant persistence solution.",
-  "version": "0.6.3",
+  "version": "0.6.5",
   "main": "src/Lawnchair.js",
   "scripts": [
     "src/Lawnchair.js"


### PR DESCRIPTION
I noticed that the version tag in component.json was not up to date. Also renamed component.json to bower.json which is the now preferred name for the file. This helps with auto injection tools like gulp-bower-files.
