### PR TITLE
Add missing semicolons that break JS concatenation

### DIFF
--- a/src/plugins/callbacks.js
+++ b/src/plugins/callbacks.js
@@ -82,5 +82,5 @@ Lawnchair.plugin((function(){
     
     // end module
     }
-})())
+})());
 

--- a/src/plugins/query.js
+++ b/src/plugins/query.js
@@ -62,4 +62,4 @@ Lawnchair.plugin((function(){
         }
     } 
 ///// 
-})())
+})());


### PR DESCRIPTION
Missing semicolon breaks concatenation of plugins
