### PR TITLE
Adapters are now added to the end of the list.

### DIFF
--- a/src/Lawnchair.js
+++ b/src/Lawnchair.js
@@ -92,7 +92,7 @@ Lawnchair.adapter = function (id, obj) {
     }
     // if we made it this far the adapter interface is valid 
     // insert the new adapter as the preferred adapter
-    Lawnchair.adapters.splice(0,0,obj)
+    Lawnchair.adapters.splice(Lawnchair.adapters.length,0,obj)
 }
 
 Lawnchair.plugins = []


### PR DESCRIPTION
Fixes #213.  Array.prototype.splice is still used to mutate the array in-place, but it now adds the adapters to the end of the list to make them listed in "failback order".