### PR TITLE
docs: Fix simple typo, particularily -> particularly

### DIFF
--- a/lib/lawnchair.js
+++ b/lib/lawnchair.js
@@ -392,7 +392,7 @@ Lawnchair.adapter('dom', (function() {
 
         batch: function (ary, callback) {
             var saved = []
-            // not particularily efficient but this is more for sqlite situations
+            // not particularly efficient but this is more for sqlite situations
             for (var i = 0, l = ary.length; i < l; i++) {
                 this.save(ary[i], function(r){
                     saved.push(r)

--- a/src/adapters/chrome-storage.js
+++ b/src/adapters/chrome-storage.js
@@ -136,7 +136,7 @@ Lawnchair.adapter('chrome-storage', (function() {
 
         batch: function (ary, callback) {
             var saved = []
-            // not particularily efficient but this is more for sqlite situations
+            // not particularly efficient but this is more for sqlite situations
             for (var i = 0, l = ary.length; i < l; i++) {
                 this.save(ary[i], function(r){
                     saved.push(r)

--- a/src/adapters/dom.js
+++ b/src/adapters/dom.js
@@ -92,7 +92,7 @@ Lawnchair.adapter('dom', (function() {
 
         batch: function (ary, callback) {
             var saved = []
-            // not particularily efficient but this is more for sqlite situations
+            // not particularly efficient but this is more for sqlite situations
             for (var i = 0, l = ary.length; i < l; i++) {
                 this.save(ary[i], function(r){
                     saved.push(r)


### PR DESCRIPTION
There is a small typo in lib/lawnchair.js, src/adapters/chrome-storage.js, src/adapters/dom.js.

Should read `particularly` rather than `particularily`.

